### PR TITLE
Add decorator support + cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Or with ES7 decorators:
 export default class MyScreenView extends React.Component {
   // ...
 }
+```
 
 
 ------------

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # react-navigation-is-focused-hoc [![npm version](https://badge.fury.io/js/react-navigation-is-focused-hoc.svg)](https://badge.fury.io/js/react-navigation-is-focused-hoc)
 
-## Welcome React Navigation user seeking focus 😀
+## Welcome React Navigation user seeking focus 
 
 This is a quick, ready to use solution using HOC to expose `props.isFocused`. **No Redux needed**
 
@@ -79,6 +79,13 @@ class MyScreenView extends React.Component {
 // second argument is the route name specified during StackNavigator initialization.
 export default withNavigationFocus(MyScreenView, 'MyScreenView')
 ```
+
+Or with ES7 decorators:
+```javascript
+@withNavigationFocus('MyScreenView')
+export default class MyScreenView extends React.Component {
+  // ...
+}
 
 
 ------------

--- a/index.js
+++ b/index.js
@@ -1,67 +1,75 @@
-import React from 'react'
+import React from 'react';
 
 // subscribed components update functions
-let subscribedComponents = []
+let subscribedComponents = [];
 
 
 function _getCurrentRouteName(navigationState) {
-  if (!navigationState) return null
-  const route = navigationState.routes[navigationState.index]
-  if (route.routes) return _getCurrentRouteName(route)
-  return route.routeName
+    if (!navigationState) return null;
+    const route = navigationState.routes[navigationState.index];
+    if (route.routes) return _getCurrentRouteName(route);
+    return route.routeName;
 }
 
 function updateFocus(currentState) {
-  const currentRoute = _getCurrentRouteName(currentState)
-  subscribedComponents.forEach((f) => f(currentRoute))
+    const currentRoute = _getCurrentRouteName(currentState);
+    subscribedComponents.forEach((f) => f(currentRoute));
 }
 
-function withNavigationFocus(WrappedComponent, screenName) {
-
-  return class extends React.Component {
-    static navigationOptions = (props) => {
-      if (typeof WrappedComponent.navigationOptions === 'function') {
-        return WrappedComponent.navigationOptions(props)
-      }
-      return { ...WrappedComponent.navigationOptions }
+function withNavigationFocus(WrappedComponent, screenName = null) {
+    if (typeof WrappedComponent === 'string') {
+        screenName = WrappedComponent;
+        return (WrappedComponent) => _bind(WrappedComponent, screenName);
+    } else {
+        return _bind(WrappedComponent, screenName);
     }
+}
 
-    constructor(props) {
-      super(props)
-      this.state = {
-        isFocused: true
-      }
-    }
+function _bind(WrappedComponent, screenName) {
+    return class extends React.Component {
+        static navigationOptions = (props) => {
+            if (typeof WrappedComponent.navigationOptions === 'function') {
+                return WrappedComponent.navigationOptions(props);
+            }
+            return {...WrappedComponent.navigationOptions};
+        };
 
-    componentDidMount() {
-      subscribedComponents.push(this._handleNavigationChange)
-    }
-
-    componentWillUnmount() {
-      for (var i = 0; i < subscribedComponents.length; i++) {
-        if (subscribedComponents[i] === this._handleNavigationChange) {
-          subscribedComponents.splice(i, 1)
-          break
+        constructor(props) {
+            super(props);
+            this.state = {
+                isFocused: true
+            }
         }
-      }
-    }
 
-    _handleNavigationChange = (routeName) => {
-      // update state only when isFocused changes
-      if (this.state.isFocused !== (screenName === routeName)) {
-        this.setState({
-          isFocused: screenName === routeName
-        })
-      }
-    }
+        componentDidMount() {
+            subscribedComponents.push(this._handleNavigationChange);
+        }
 
-    render() {
-      return <WrappedComponent isFocused={this.state.isFocused} {...this.props} />
+        componentWillUnmount() {
+            for (let i = 0; i < subscribedComponents.length; i++) {
+                if (subscribedComponents[i] === this._handleNavigationChange) {
+                    subscribedComponents.splice(i, 1);
+                    break;
+                }
+            }
+        }
+
+        _handleNavigationChange = (routeName) => {
+            // update state only when isFocused changes
+            if (this.state.isFocused !== (screenName === routeName)) {
+                this.setState({
+                    isFocused: screenName === routeName
+                })
+            }
+        };
+
+        render() {
+            return <WrappedComponent isFocused={this.state.isFocused} {...this.props} />
+        }
     }
-  }
 }
 
 module.exports = {
-  withNavigationFocus,
-  updateFocus,
-}
+    withNavigationFocus,
+    updateFocus
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-navigation-is-focused-hoc",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Ready to use solution using HOC to expose props.isFocused for react-navigation. No Redux needed.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I've made withNavigationFocus usable with ES7 decorators.

Also made a general cleanup and made the code more consistent (`;`, etc).